### PR TITLE
Allowing an object or string to be parsed for activities

### DIFF
--- a/lib/es6/activities/activityMarkup.js
+++ b/lib/es6/activities/activityMarkup.js
@@ -59,13 +59,18 @@ ActivityMarkup.prototype._registerSystemTypes = function () {
     this._registerTypes(__dirname);
 };
 
-ActivityMarkup.prototype._registerTypes = function (sourcePath) {
-    this._registerTypesTo(this._systemTypes, sourcePath);
+ActivityMarkup.prototype._registerTypes = function (source) {
+    this._registerTypesTo(this._systemTypes, source);
 };
 
-ActivityMarkup.prototype._registerTypesTo = function (types, sourcePath) {
+ActivityMarkup.prototype._registerTypesTo = function (types, source) {
     let self = this;
-    let obj = requireFromRoot(sourcePath);
+    let obj;
+    if (typeof source === 'object') {
+        obj = source;
+    } else {
+        obj = requireFromRoot(source);
+    }
     Reflection.visitObject(obj, function (inObj) {
         let alias = self.getAlias(inObj);
         if (alias && !types.has(alias)) {


### PR DESCRIPTION
This allows an object to be passed directly in to be parsed for activities. This makes it so it won't matter where you run your node process from.