### PR TITLE
Handle inheritance in es6 classes

### DIFF
--- a/lib/es6/activities/activity.js
+++ b/lib/es6/activities/activity.js
@@ -573,12 +573,16 @@ Activity.prototype._getScopeKeys = function () {
     let self = this;
 
     // Handle ES6 Classes and moving data to scope
-    let props = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
-    props.forEach((prop) => {
-      if(prop !== 'constructor') {
-        self[prop] = this[prop];
-      }
-    });
+    let prototype = Object.getPrototypeOf(this);
+    while(prototype && prototype !== Activity.prototype) {
+      const props = Object.getOwnPropertyNames(prototype);
+      props.forEach( (prop) => {
+        if(prop !== 'constructor') {
+          self[prop] = this[prop];
+        }
+      });
+      prototype = Object.getPrototypeOf(prototype);
+    }
 
     if (!self._scopeKeys || !self._structureInitialized) {
         self._scopeKeys = [];


### PR DESCRIPTION
getOwnPropertyNames does not retrieve the properties of inherited classes. This will traverse the prototype chain (down to Activity) to add in all the missed properties.