### PR TITLE
Fix isFunctionString Regex

### DIFF
--- a/lib/es5/activities/templateHelpers.js
+++ b/lib/es5/activities/templateHelpers.js
@@ -8,7 +8,7 @@ var maxDepth = 10;
 var templateHelpers = {
 
     isFunctionString: function isFunctionString(str) {
-        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/);
+        return _.isString(str) && /^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/.test(str);
     },
     isTemplate: function isTemplate(obj) {
         var activityCount = 0;

--- a/lib/es5/activities/templateHelpers.js
+++ b/lib/es5/activities/templateHelpers.js
@@ -8,7 +8,7 @@ var maxDepth = 10;
 var templateHelpers = {
 
     isFunctionString: function isFunctionString(str) {
-        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\((?:\w+,)*(?:\w+)?\)\s*\{/);
+        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/);
     },
     isTemplate: function isTemplate(obj) {
         var activityCount = 0;

--- a/lib/es6/activities/templateHelpers.js
+++ b/lib/es6/activities/templateHelpers.js
@@ -8,7 +8,7 @@ let maxDepth = 10;
 let templateHelpers = {
 
     isFunctionString: function (str) {
-        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/);
+        return _.isString(str) && /^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/.test(str);
     },
     isTemplate: function (obj) {
         let activityCount = 0;

--- a/lib/es6/activities/templateHelpers.js
+++ b/lib/es6/activities/templateHelpers.js
@@ -8,7 +8,7 @@ let maxDepth = 10;
 let templateHelpers = {
 
     isFunctionString: function (str) {
-        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\((?:\w+,)*(?:\w+)?\)\s*\{/);
+        return _.isString(str) && str.match(/^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/);
     },
     isTemplate: function (obj) {
         let activityCount = 0;

--- a/lib/es6/activities/templateHelpers.js
+++ b/lib/es6/activities/templateHelpers.js
@@ -8,7 +8,7 @@ let maxDepth = 10;
 let templateHelpers = {
 
     isFunctionString: function (str) {
-        return _.isString(str) && /^\s*function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/.test(str);
+        return _.isString(str) && /^\s*(async\s+)?function\s*\w*\s*\(\s*((\w+)*|((\w+)(\s*,\s*\w+)+))\s*\)\s*\{/.test(str);
     },
     isTemplate: function (obj) {
         let activityCount = 0;


### PR DESCRIPTION
I found that when I used `@func` with a `code` value of a function with more than 1 parameter, it would complain that `code` wasn't a function. I traced it back to this, where it detects if the string value represents a function, and found a flaw with the regex used. If the value didn't pass this test, it wouldn't get parsed as a function, and then `@func`'s `code` would simply contain a string, and would purposely fail the activity.
I tested this new regex against 41 different inputs, both valid and invalid, to make sure the regex was matching correctly.
Also, just to be more semantically correct, I changed the use of `String.prototype.match` to `RegExp.prototype.test`. In that change, I also removed the use of `?:` (non-capture groups) because they were redundant. I checked the use of `isFunctionString` throughout the project to make sure nothing was accessing capture groups, to ensure the change to `test` was valid.
Finally, I added some `\s*` to the regex to allow for more valid whitespace in between certain characters.

As a reference, here's visual representations of before and after:
 - Before: https://regexper.com/#%2F%5E%5Cs*function%5Cs*%5Cw*%5Cs*%5C((%3F%3A%5Cw%2B%2C)*(%3F%3A%5Cw%2B)%3F%5C)%5Cs*%5C%7B%2F
 - After: (ES5) https://regexper.com/#%2F%5E%5Cs*function%5Cs*%5Cw*%5Cs*%5C(%5Cs*((%5Cw%2B)*%7C((%5Cw%2B)(%5Cs*%2C%5Cs*%5Cw%2B)%2B))%5Cs*%5C)%5Cs*%5C%7B%2F and (ES6) https://regexper.com/#%2F%5E%5Cs*(async%5Cs%2B)%3Ffunction%5Cs*%5Cw*%5Cs*%5C(%5Cs*((%5Cw%2B)*%7C((%5Cw%2B)(%5Cs*%2C%5Cs*%5Cw%2B)%2B))%5Cs*%5C)%5Cs*%5C%7B%2F